### PR TITLE
P81-113711 chore(security): pin 3rd party actions to SHA commits [skip actions]

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,11 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
       with:
         go-version: ${{ matrix.go-version }}
     - name: Check out repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
     - name: Install Go dependencies
       run: go get golang.org/x/tools/cmd/cover
     - name: Check modules
@@ -38,7 +38,7 @@ jobs:
     - name: Test
       run: SUDO_PERMITTED=1 ./test
     - name: Run linter
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3
       with:
         version: v1.55.1
         args: -E=gofmt --timeout=30m0s

--- a/.github/workflows/spectralops_scan.yaml
+++ b/.github/workflows/spectralops_scan.yaml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Use SpectralOps Scanner action
-        uses: perimeter-81/actions/actions/security/spectralops@main
+        uses: perimeter-81/actions/actions/security/spectralops@main # zizmor: ignore[unpinned-uses]
         with:
           spectral-args: "scan --ok --engines oss,secrets,iac --asset-mapping 'p81-core'"


### PR DESCRIPTION
## Describe your changes

Pin all 3rd party GitHub Actions to full SHA commit hashes to prevent supply-chain attacks.

### What was done:
- **SHA pinning**: Replaced version tags (e.g., `@v4`) with full SHA commits — versions NOT upgraded
- **Zizmor compliance**: Added `# zizmor: ignore[unpinned-uses]` to all internal `perimeter-81/actions/...` refs

### External actions pinned (3):
- `actions/checkout@v3` → `@f43a0e5ff2bd2940...`
- `actions/setup-go@v4` → `@7b8cf10d4e4a01d4...`
- `golangci/golangci-lint-action@v3` → `@3a919529898de77e...`

## Jira ticket
_(none)_

## Tests
- All YAML files pass `yaml.safe_load()` validation
- No remaining 3rd party actions using version tags (verified)
- No remaining internal actions missing `# zizmor: ignore[unpinned-uses]`

## Checklist
- [x] Self-review performed
- [x] All 3rd party actions pinned to SHA commits (not version tags)
- [x] Versions NOT upgraded — only pinned to existing tag's SHA
