### PR TITLE
P81-113711 chore(security): pin 3rd party actions to SHA commits [skip actions]

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,11 +24,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.x
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4
       with:
         go-version: ${{ matrix.go-version }}
     - name: Check out repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
     - name: Install Go dependencies
       run: go get golang.org/x/tools/cmd/cover
     - name: Check modules
@@ -38,7 +38,7 @@ jobs:
     - name: Test
       run: SUDO_PERMITTED=1 ./test
     - name: Run linter
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3
       with:
         version: v1.55.1
         args: -E=gofmt --timeout=30m0s

--- a/.github/workflows/spectralops_scan.yaml
+++ b/.github/workflows/spectralops_scan.yaml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Use SpectralOps Scanner action
-        uses: perimeter-81/actions/actions/security/spectralops@main
+        uses: perimeter-81/actions/actions/security/spectralops@main # zizmor: ignore[unpinned-uses]
         with:
           spectral-args: "scan --ok --engines oss,secrets,iac --asset-mapping 'p81-core'"

--- a/.github/workflows/spectralops_scan.yaml
+++ b/.github/workflows/spectralops_scan.yaml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Use SpectralOps Scanner action
-        uses: perimeter-81/actions/actions/security/spectralops@main # zizmor: ignore[unpinned-uses]
+        uses: perimeter-81/actions/actions/security/spectralops@v1 # zizmor: ignore[unpinned-uses]
         with:
           spectral-args: "scan --ok --engines oss,secrets,iac --asset-mapping 'p81-core'"


### PR DESCRIPTION
## Summary
- Pin 3rd party GitHub Actions to SHA commit hashes for supply-chain security
- Set internal actions (`perimeter-81/actions/actions/...`) to `@v1` with `# zizmor: ignore[unpinned-uses]`
- Prevents supply-chain attacks via tag mutation

Part of epic [P81-113387](https://perimeter81.atlassian.net/browse/P81-113387)

## Review guidelines

### 1. Internal actions must be pinned to `@v1`

```yaml
# ✅ Correct
uses: perimeter-81/actions/actions/aws/assume_role_v2@v1 # zizmor: ignore[unpinned-uses]

# ❌ Wrong — points to @main or feature branch
uses: perimeter-81/actions/actions/aws/assume_role@main # zizmor: ignore[unpinned-uses]
```

### 2. 3rd party actions must be pinned to full SHA with version comment

```yaml
# ✅ Correct
uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4

# ❌ Wrong — version tag instead of SHA
uses: actions/checkout@v4

# ❌ Wrong — SHA without version comment
uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
```

### Quick validation
```bash
# 3rd party still using version tags
grep -rn "uses:" .github/workflows/ | grep -v "perimeter-81/" | grep "@v"

# 3rd party missing version comment
grep -rn "uses:" .github/workflows/ | grep "@[a-f0-9]\{40\}" | grep -v "#"

# Internal actions not pinned to @v1
grep -rn "uses:.*perimeter-81/actions/actions/" .github/workflows/ | grep -v "@v1"
```

## Test plan
- [ ] Verify workflow files have correct SHA pins with version comments
- [ ] Verify internal actions point to `@v1` with zizmor comment

[P81-113387]: https://perimeter81.atlassian.net/browse/P81-113387?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ