### PR TITLE
[skip actions] P81-120664 Migrate to self-hosted runner

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.16.x, 1.17.x, 1.18.x, 1.19.x, 1.20.x]
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ACTIONS_RUNNER }}
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4

--- a/.github/workflows/spectralops_scan.yaml
+++ b/.github/workflows/spectralops_scan.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   spectralops_scan:
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.ACTIONS_RUNNER }}
     steps:
       - name: Use SpectralOps Scanner action
         uses: perimeter-81/actions/actions/security/spectralops@v1 # zizmor: ignore[unpinned-uses]


### PR DESCRIPTION
Jira: https://perimeter81.atlassian.net/browse/P81-120664

## Changes

Migrated all workflow `runs-on` values to use `${{ vars.ACTIONS_RUNNER }}`.

Runner selected because: repository does not require Docker-in-Docker.

## Modified workflow files

- `.github/workflows/go.yml`
- `.github/workflows/spectralops_scan.yaml`

---
Co-authored-by: Claude (claude-sonnet-4-6)